### PR TITLE
Replace hashlib with crypto

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,7 +29,7 @@ var 	net = require("net"),
 	util = require("util"),
 	crypto = require("crypto"),
 	events = require("events"),
-	hashlib = require("hashlib");
+	crypto = require("crypto");
 
 // Constructor
 function POP3Client(port, host, options) {
@@ -450,7 +450,9 @@ POP3Client.prototype.apop = function (username, password) {
 		});
 
 		self.setMultiline(false);
-		self.write("APOP", username + " " + hashlib.md5(self.data["apop-timestamp"] + password));
+		var cryptoMd5 = crypto.createHash('md5');
+		cryptoMd5.update(self.data["apop-timestamp"] + password);
+		self.write("APOP", username + " " + cryptoMd5.digest('hex'));
 
 	}
 };

--- a/main.js
+++ b/main.js
@@ -29,7 +29,7 @@ var 	net = require("net"),
 	util = require("util"),
 	crypto = require("crypto"),
 	events = require("events"),
-	crypto = require("crypto");
+	hashlib = require("hashlib2");
 
 // Constructor
 function POP3Client(port, host, options) {
@@ -450,9 +450,7 @@ POP3Client.prototype.apop = function (username, password) {
 		});
 
 		self.setMultiline(false);
-		var cryptoMd5 = crypto.createHash('md5');
-		cryptoMd5.update(self.data["apop-timestamp"] + password);
-		self.write("APOP", username + " " + cryptoMd5.digest('hex'));
+		self.write("APOP", username + " " + hashlib.md5(self.data["apop-timestamp"] + password));
 
 	}
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
             "email": "ditesh@gathani.org",
             "url": "http://ditesh.gathani.org/blog/"
     },
-	"dependencies": ["optimist", "hashlib"],
+	"dependencies": ["optimist"],
     "repository": { "type" : "git", "url" : "https://github.com/ditesh/node-poplib.git" },
     "main": "main.js"
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
             "email": "ditesh@gathani.org",
             "url": "http://ditesh.gathani.org/blog/"
     },
-	"dependencies": ["optimist"],
+	"dependencies": ["optimist", "hashlib2"],
     "repository": { "type" : "git", "url" : "https://github.com/ditesh/node-poplib.git" },
     "main": "main.js"
 }


### PR DESCRIPTION
Removed the requirement for hashlib because it no longer works well on node 0.6.
