### PR TITLE
fixing securePair unhandled exception in starttls()

### DIFF
--- a/main.js
+++ b/main.js
@@ -142,7 +142,11 @@ function POP3Client(port, host, options) {
 
 		var sslcontext = require('crypto').createCredentials(options);
 		var pair = tls.createSecurePair(sslcontext, false);
-		var cleartext = pipe(pair);
+		function onTlsError(e){
+                   self.emit('error',e);
+                }
+                pair.on('error', onTlsError);
+                var cleartext = pipe(pair);
 
 		pair.on('secure', function() {
 

--- a/main.js
+++ b/main.js
@@ -844,7 +844,7 @@ POP3Client.prototype.capa = function() {
 };
 
 POP3Client.prototype.quit = function() {
-
+    try{
 	var self = this;
 
 	if (self.getState() === 0) self.emit("invalid-state", "quit");
@@ -866,6 +866,9 @@ POP3Client.prototype.quit = function() {
 		self.write("QUIT", undefined);
 
 	}
+      }catch(e){
+        self.emit('error',e);
+      }
 };
 
 module.exports = POP3Client;


### PR DESCRIPTION
When connecting bu fault to an imap server, an exception occurs, this exception cannot be handled as it does not arrive to my app layer. Adding a onError listener to the securePair in starttls() solved this.
