### PR TITLE
servername param added for Servername Indication

### DIFF
--- a/main.js
+++ b/main.js
@@ -281,7 +281,8 @@ function POP3Client(port, host, options) {
 		tlssock = tls.connect({
             host: host,
             port: port,
-            rejectUnauthorized: !self.data.ignoretlserrs
+            rejectUnauthorized: !self.data.ignoretlserrs,
+			servername: host
         }, function() {
 
             if (tlssock.authorized === false && 


### PR DESCRIPTION
@ditesh , 

Recently while working on Node 14, I faced an error with Gmail Accounts in production.

```
self signed certificate
    at TLSSocket.onConnectSecure (_tls_wrap.js:1497:34)
    at TLSSocket.emit (events.js:315:20)
    at TLSSocket._finishInit (_tls_wrap.js:932:8)
    at TLSWrap.ssl.onhandshakedone (_tls_wrap.js:706:12) {
  code: 'DEPTH_ZERO_SELF_SIGNED_CERT'
}
```
Referring to issue https://github.com/nodejs/node/issues/28167 and from the node js documentation (https://nodejs.org/docs/latest-v14.x/api/tls.html), SNI ( server name identification ) needs to be passed when connecting to Gmail pop3 server, which used to be sent by default before node 12. I have passed the parameter ``` servername``` to the ```tls.connect()``` method to fix my problem. 

You are requested to have a look at the PR and suggest if it can be merged.
Thanks 
